### PR TITLE
Made dependency to mockito for test scope only

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>1.10.19</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Dependency to mockito is currently in compile scope which forces everyone who uses this library to exclude mockito for regular usage.
Cheers,
Sven
