### PR TITLE
Add ZonedDateTime

### DIFF
--- a/src/main/java/io/craftsman/Jdk8CompatibilityConverter.java
+++ b/src/main/java/io/craftsman/Jdk8CompatibilityConverter.java
@@ -1,9 +1,16 @@
 package io.craftsman;
 
-import io.craftsman.creator.CreatorFactory;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.Period;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
 import org.dozer.CustomConverter;
 
-import java.time.*;
+import io.craftsman.creator.CreatorFactory;
 
 public class Jdk8CompatibilityConverter implements CustomConverter {
 
@@ -30,7 +37,9 @@ public class Jdk8CompatibilityConverter implements CustomConverter {
         } else if (destinationClass.isAssignableFrom(Duration.class) && sourceClass.isAssignableFrom(Duration.class)) {
             destination = creatorFactory.createDurationCreator().create(source);
         } else if (destinationClass.isAssignableFrom(Period.class) && sourceClass.isAssignableFrom(Period.class)) {
-            destination = creatorFactory.createPeriodCreator().create(source);
+        	destination = creatorFactory.createPeriodCreator().create(source);
+        } else if (destinationClass.isAssignableFrom(ZonedDateTime.class) && sourceClass.isAssignableFrom(ZonedDateTime.class)) {
+            destination = creatorFactory.createZonedDateTimeCreator().create(source);
         }
 
         return destination;

--- a/src/main/java/io/craftsman/Jdk8CompatibilityConverter.java
+++ b/src/main/java/io/craftsman/Jdk8CompatibilityConverter.java
@@ -1,16 +1,9 @@
 package io.craftsman;
 
-import java.time.Duration;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.Period;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-
+import io.craftsman.creator.CreatorFactory;
 import org.dozer.CustomConverter;
 
-import io.craftsman.creator.CreatorFactory;
+import java.time.*;
 
 public class Jdk8CompatibilityConverter implements CustomConverter {
 

--- a/src/main/java/io/craftsman/creator/CreatorFactory.java
+++ b/src/main/java/io/craftsman/creator/CreatorFactory.java
@@ -7,6 +7,8 @@ public class CreatorFactory {
     private LocalTimeCreator localTimeCreator;
 
     private LocalDateTimeCreator localDateTimeCreator;
+    
+    private ZonedDateTimeCreator zonedDateTimeCreator;
 
     private ZoneIdCreator zoneIdCreator;
 
@@ -32,10 +34,17 @@ public class CreatorFactory {
     }
 
     public LocalDateTimeCreator createLocalDateTimeCreator() {
-        if (localDateTimeCreator == null) {
-            localDateTimeCreator = new LocalDateTimeCreator();
+    	if (localDateTimeCreator == null) {
+    		localDateTimeCreator = new LocalDateTimeCreator();
+    	}
+    	return localDateTimeCreator;
+    }
+    
+    public ZonedDateTimeCreator createZonedDateTimeCreator() {
+        if (zonedDateTimeCreator == null) {
+            zonedDateTimeCreator = new ZonedDateTimeCreator();
         }
-        return localDateTimeCreator;
+        return zonedDateTimeCreator;
     }
 
     public ZoneIdCreator createZoneIdCreator() {

--- a/src/main/java/io/craftsman/creator/ZonedDateTimeCreator.java
+++ b/src/main/java/io/craftsman/creator/ZonedDateTimeCreator.java
@@ -1,0 +1,21 @@
+package io.craftsman.creator;
+
+import java.time.ZonedDateTime;
+
+public class ZonedDateTimeCreator implements Creator<ZonedDateTime> {
+
+    @Override
+    public ZonedDateTime create(Object source) {
+    	ZonedDateTime srcObject = (ZonedDateTime) source;
+        return ZonedDateTime.of(
+                srcObject.getYear(),
+                srcObject.getMonthValue(),
+                srcObject.getDayOfMonth(),
+                srcObject.getHour(),
+                srcObject.getMinute(),
+                srcObject.getSecond(),
+                srcObject.getNano(),
+                srcObject.getZone()
+        );
+    }
+}

--- a/src/main/resources/dozerJdk8Converters.xml
+++ b/src/main/resources/dozerJdk8Converters.xml
@@ -18,6 +18,10 @@
                 <class-b>java.time.LocalDateTime</class-b>
             </converter>
             <converter type="io.craftsman.Jdk8CompatibilityConverter">
+                <class-a>java.time.ZonedDateTime</class-a>
+                <class-b>java.time.ZonedDateTime</class-b>
+            </converter>
+            <converter type="io.craftsman.Jdk8CompatibilityConverter">
                 <class-a>java.time.ZoneId</class-a>
                 <class-b>java.time.ZoneId</class-b>
             </converter>

--- a/src/test/java/io/craftsman/Jdk8CompatibilityConverterTest.java
+++ b/src/test/java/io/craftsman/Jdk8CompatibilityConverterTest.java
@@ -1,13 +1,13 @@
 package io.craftsman;
 
-
 import io.craftsman.creator.*;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner; 		 
+import org.mockito.runners.MockitoJUnitRunner;
+
 import java.time.*;
 import java.time.temporal.ChronoUnit;
 

--- a/src/test/java/io/craftsman/Jdk8CompatibilityConverterTest.java
+++ b/src/test/java/io/craftsman/Jdk8CompatibilityConverterTest.java
@@ -7,16 +7,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
- 		 
+import org.mockito.runners.MockitoJUnitRunner; 		 
 import java.time.*;
 import java.time.temporal.ChronoUnit;
-
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.*;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/io/craftsman/Jdk8CompatibilityConverterTest.java
+++ b/src/test/java/io/craftsman/Jdk8CompatibilityConverterTest.java
@@ -1,6 +1,22 @@
 package io.craftsman;
 
-import io.craftsman.creator.*;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.Period;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -8,14 +24,14 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import java.time.*;
-import java.time.temporal.ChronoUnit;
-
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.*;
+import io.craftsman.creator.CreatorFactory;
+import io.craftsman.creator.DurationCreator;
+import io.craftsman.creator.LocalDateCreator;
+import io.craftsman.creator.LocalDateTimeCreator;
+import io.craftsman.creator.LocalTimeCreator;
+import io.craftsman.creator.PeriodCreator;
+import io.craftsman.creator.ZoneIdCreator;
+import io.craftsman.creator.ZonedDateTimeCreator;
 
 @RunWith(MockitoJUnitRunner.class)
 public class Jdk8CompatibilityConverterTest {
@@ -28,6 +44,9 @@ public class Jdk8CompatibilityConverterTest {
 
     @Mock
     private LocalDateTimeCreator localDateTimeCreatorMock;
+    
+    @Mock
+    private ZonedDateTimeCreator zonedDateTimeCreatorMock;
 
     @Mock
     private ZoneIdCreator zoneIdCreatorMock;
@@ -50,6 +69,7 @@ public class Jdk8CompatibilityConverterTest {
         when(creatorFactoryMock.createLocalDateCreator()).thenReturn(localDateCreatorMock);
         when(creatorFactoryMock.createLocalTimeCreator()).thenReturn(localTimeCreatorMock);
         when(creatorFactoryMock.createLocalDateTimeCreator()).thenReturn(localDateTimeCreatorMock);
+        when(creatorFactoryMock.createZonedDateTimeCreator()).thenReturn(zonedDateTimeCreatorMock);
         when(creatorFactoryMock.createZoneIdCreator()).thenReturn(zoneIdCreatorMock);
         when(creatorFactoryMock.createDurationCreator()).thenReturn(durationCreatorMock);
         when(creatorFactoryMock.createPeriodCreator()).thenReturn(periodCreatorMock);
@@ -116,17 +136,32 @@ public class Jdk8CompatibilityConverterTest {
 
     @Test
     public void testConvertLocalDateTime() {
-        LocalDateTime sourceLocalDateTime = LocalDateTime.now();
-        LocalDateTime destinationLocalDateTime = null;
+    	LocalDateTime sourceLocalDateTime = LocalDateTime.now();
+    	LocalDateTime destinationLocalDateTime = null;
+    	
+    	when(localDateTimeCreatorMock.create(sourceLocalDateTime)).thenReturn(sourceLocalDateTime);
+    	
+    	Object actualLocalDateTime = objectUnderTest.convert(destinationLocalDateTime, sourceLocalDateTime, LocalDateTime.class, LocalDateTime.class);
+    	
+    	assertThat(actualLocalDateTime, instanceOf(LocalDateTime.class));
+    	assertEquals(sourceLocalDateTime, actualLocalDateTime);
+    	
+    	verify(localDateTimeCreatorMock, times(1)).create(sourceLocalDateTime);
+    }
+    
+    @Test
+    public void testConvertZonedDateTime() {
+        ZonedDateTime sourceZonedDateTime = ZonedDateTime.now();
+        ZonedDateTime destinationZonedDateTime = null;
 
-        when(localDateTimeCreatorMock.create(sourceLocalDateTime)).thenReturn(sourceLocalDateTime);
+        when(zonedDateTimeCreatorMock.create(sourceZonedDateTime)).thenReturn(sourceZonedDateTime);
 
-        Object actualLocalDateTime = objectUnderTest.convert(destinationLocalDateTime, sourceLocalDateTime, LocalDateTime.class, LocalDateTime.class);
+        Object actualZonedDateTime = objectUnderTest.convert(destinationZonedDateTime, sourceZonedDateTime, ZonedDateTime.class, ZonedDateTime.class);
 
-        assertThat(actualLocalDateTime, instanceOf(LocalDateTime.class));
-        assertEquals(sourceLocalDateTime, actualLocalDateTime);
+        assertThat(actualZonedDateTime, instanceOf(ZonedDateTime.class));
+        assertEquals(sourceZonedDateTime, actualZonedDateTime);
 
-        verify(localDateTimeCreatorMock, times(1)).create(sourceLocalDateTime);
+        verify(zonedDateTimeCreatorMock, times(1)).create(sourceZonedDateTime);
     }
 
     @Test

--- a/src/test/java/io/craftsman/Jdk8CompatibilityConverterTest.java
+++ b/src/test/java/io/craftsman/Jdk8CompatibilityConverterTest.java
@@ -1,37 +1,28 @@
 package io.craftsman;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
-import java.time.Duration;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.Period;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-import java.time.temporal.ChronoUnit;
-
+import io.craftsman.creator.*;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+ 		 
+import java.time.*;
+import java.time.temporal.ChronoUnit;
 
-import io.craftsman.creator.CreatorFactory;
-import io.craftsman.creator.DurationCreator;
-import io.craftsman.creator.LocalDateCreator;
-import io.craftsman.creator.LocalDateTimeCreator;
-import io.craftsman.creator.LocalTimeCreator;
-import io.craftsman.creator.PeriodCreator;
-import io.craftsman.creator.ZoneIdCreator;
-import io.craftsman.creator.ZonedDateTimeCreator;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.*;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class Jdk8CompatibilityConverterTest {

--- a/src/test/java/io/craftsman/creator/CreatorFactoryTest.java
+++ b/src/test/java/io/craftsman/creator/CreatorFactoryTest.java
@@ -26,7 +26,12 @@ public class CreatorFactoryTest {
 
     @Test
     public void testCreateLocalDateTimeCreator() {
-        assertNotNull(objectUnderTest.createLocalDateTimeCreator());
+    	assertNotNull(objectUnderTest.createLocalDateTimeCreator());
+    }
+    
+    @Test
+    public void testCreateZonedDateTimeCreator() {
+        assertNotNull(objectUnderTest.createZonedDateTimeCreator());
     }
 
     @Test

--- a/src/test/java/io/craftsman/creator/ZonedDateTimeCreatorTest.java
+++ b/src/test/java/io/craftsman/creator/ZonedDateTimeCreatorTest.java
@@ -1,0 +1,25 @@
+package io.craftsman.creator;
+
+import static org.junit.Assert.assertEquals;
+
+import java.time.ZonedDateTime;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class ZonedDateTimeCreatorTest {
+
+    private ZonedDateTimeCreator objectUnderTest;
+
+    @Before
+    public void setUp() {
+        objectUnderTest = new ZonedDateTimeCreator();
+    }
+
+    @Test
+    public void testCreate() {
+        ZonedDateTime zonedDateTime = ZonedDateTime.now();
+        ZonedDateTime actualDateTime = objectUnderTest.create(zonedDateTime);
+        assertEquals(zonedDateTime, actualDateTime);
+    }
+}


### PR DESCRIPTION
Thanks for this much needed addition to Dozer.  

Even though Dozer has not had an update in almost 3 years, it still offers some of the best mapping strategies I've seen thus far.  Guess it's up to additional support libraries like this one to keep it alive long enough from everybody to start using a new one.

I noticed you did not have ZonedDateTime as one of your types, so I added it.  I fits in all the same places as LocalDateTime