### PR TITLE
Added java.time.Instant converter block to dozerJdk8Converters.xml

### DIFF
--- a/src/main/resources/dozerJdk8Converters.xml
+++ b/src/main/resources/dozerJdk8Converters.xml
@@ -36,6 +36,10 @@
                 <class-a>java.time.Duration</class-a>
                 <class-b>java.time.Duration</class-b>
             </converter>
+            <converter type="io.craftsman.Jdk8CompatibilityConverter">
+                <class-a>java.time.Instant</class-a>
+                <class-b>java.time.Instant</class-b>
+            </converter>
             <converter type="io.craftsman.JdkMissingConverter">
                 <class-a>java.util.Locale</class-a>
                 <class-b>java.util.Locale</class-b>


### PR DESCRIPTION
Mapper crashed when try to map java.time.Instant. One xml block config was missing in dozerJdk8Converters.xml file and I added it. Now it work fine. Cheers!